### PR TITLE
feat: add option to set custom highlight group

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sql-ghosty.nvim
 
-`sql-ghosty.nvim` adds ghost text inlay hints to your SQL insert statements. 
+`sql-ghosty.nvim` adds ghost text inlay hints to your SQL insert statements.
 
 ## Example
 
@@ -8,10 +8,10 @@
 
 ## Description
 
-Addresses the challenge of managing SQL inserts with numerous columns, where it’s difficult to map values to their corresponding columns. 
+Addresses the challenge of managing SQL inserts with numerous columns, where it’s difficult to map values to their corresponding columns.
 It embeds hints with the column name alongside each value.
 
-Another approach I sometimes use, is to align the statement with a plugin like mini.align and edit it in visual-block mode. 
+Another approach I sometimes use, is to align the statement with a plugin like mini.align and edit it in visual-block mode.
 These approaches are complementary, each valuable in different scenarios, allowing me to choose the best method based on the context.
 
 ## Features
@@ -32,7 +32,7 @@ These approaches are complementary, each valuable in different scenarios, allowi
   },
   opts = {},
 }
-```    
+```
 
 ## Configuration
 
@@ -42,6 +42,7 @@ These approaches are complementary, each valuable in different scenarios, allowi
 {
     -- if set to false the user needs to enable hints manually with :SqlInlayHintsToggle
     show_hints_by_default = true,
+    highlight_group = "DiagnosticHint",
 }
 ```
 

--- a/lua/sql-ghosty/init.lua
+++ b/lua/sql-ghosty/init.lua
@@ -6,6 +6,7 @@ local M = {}
 --- @type table<SqlGhostyOptions, any>
 local default_config = {
 	show_hints_by_default = true,
+	highlight_group = "DiagnosticHint",
 }
 
 M.config = default_config
@@ -118,7 +119,7 @@ local function add_ghost_text_for_insert(node, bufnr)
 				break
 			end
 			vim.api.nvim_buf_set_extmark(bufnr, ns_id, value.row, value.col, {
-				virt_text = { { columns[i] .. ": ", "DiagnosticHint" } },
+				virt_text = { { columns[i] .. ": ", M.config.highlight_group } },
 				virt_text_pos = "inline",
 			})
 		end


### PR DESCRIPTION
I added `highlight_group` to the config so that one could set it to the value he wants.

Also, my linter removed some whitespaces in README.md.