### PR TITLE
fix: parse also other node types

### DIFF
--- a/lua/sql-ghosty/init.lua
+++ b/lua/sql-ghosty/init.lua
@@ -74,7 +74,7 @@ local function process_insert_node(node, bufnr)
 				local row_values = {}
 				for val_node in child:iter_children() do
 					if get_node_type(val_node) == "literal" or
-					   get_node_type(val_node) == "invocation" or 
+					   get_node_type(val_node) == "invocation" or
 					   get_node_type(val_node) == "field" or
 					   get_node_type(val_node) == "case" or
 					   get_node_type(val_node) == "subquery" or

--- a/lua/sql-ghosty/init.lua
+++ b/lua/sql-ghosty/init.lua
@@ -73,7 +73,7 @@ local function process_insert_node(node, bufnr)
 				-- Values list (one row)
 				local row_values = {}
 				for val_node in child:iter_children() do
-					if get_node_type(val_node) == "literal" or 
+					if get_node_type(val_node) == "literal" or
 					   get_node_type(val_node) == "invocation" or 
 					   get_node_type(val_node) == "field" or
 					   get_node_type(val_node) == "case" or

--- a/lua/sql-ghosty/init.lua
+++ b/lua/sql-ghosty/init.lua
@@ -73,7 +73,15 @@ local function process_insert_node(node, bufnr)
 				-- Values list (one row)
 				local row_values = {}
 				for val_node in child:iter_children() do
-					if get_node_type(val_node) == "literal" then
+					if get_node_type(val_node) == "literal" or 
+					   get_node_type(val_node) == "invocation" or 
+					   get_node_type(val_node) == "field" or
+					   get_node_type(val_node) == "case" or
+					   get_node_type(val_node) == "subquery" or
+					   get_node_type(val_node) == "cast" or
+					   get_node_type(val_node) == "binary_expression" or
+					   get_node_type(val_node) == "array" or
+					   get_node_type(val_node) == "parameter" then
 						local val_text = vim.treesitter.get_node_text(val_node, bufnr)
 						local start_row, start_col = val_node:start()
 						if val_text and start_row and start_col then


### PR DESCRIPTION
Here are examples of each node type that can appear in SQL VALUES clauses:
1. literal ✅
INSERT INTO test (col1, col2, col3, col4) VALUES (123, 'text', 12.34, NULL);
- Numbers: 123, 12.34
- Strings: 'text'
- NULL: NULL
- Booleans: TRUE, FALSE
2. invocation ✅
INSERT INTO test (col1, col2) VALUES (TO_DATE('2023-01-01', 'yyyy-mm-dd'), NOW());
- Function calls with parentheses
- Examples: TO_DATE(), NOW(), CONCAT(), SUBSTRING()
3. field ✅
INSERT INTO test (col1, col2) VALUES (SYSDATE, USER);
- Database functions without parentheses
- Examples: SYSDATE, USER, CURRENT_USER, CURRENT_TIMESTAMP
4. case ✅
INSERT INTO test (col1) VALUES (CASE WHEN status = 'A' THEN 1 ELSE 0 END);
- CASE WHEN...THEN...ELSE...END expressions
5. subquery ✅
INSERT INTO test (col1) VALUES ((SELECT MAX(id) FROM other_table));
- Parenthesized SELECT statements
6. cast ✅
INSERT INTO test (col1, col2) VALUES (CAST('123' AS INTEGER), 'text'::json);
- Explicit type casting
- Examples: CAST(), :: operator
7. binary_expression ✅
INSERT INTO test (col1, col2, col3) VALUES (1 + 2, 'hello' || 'world', price * 1.1);
- Arithmetic: +, -, *, /
- Concatenation: ||
- Comparisons: >, <, =
8. array ✅
INSERT INTO test (col1) VALUES (ARRAY[1,2,3]);
- Array constructors
9. parameter ✅
INSERT INTO test (col1, col2) VALUES (?, $1);
- Prepared statement placeholders
- Examples: ?, $1, $2, :param
All these node types are now supported and will display column name hints correctly.